### PR TITLE
Enable git submodules again

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,9 @@
+[submodule "ActionBarSherlock"]
+	path = ActionBarSherlock
+	url = git://github.com/JakeWharton/ActionBarSherlock.git/
+[submodule "jni/celt"]
+	path = Plumble/jni/celt
+	url = git://git.xiph.org/celt.git/
+[submodule "jni/speex"]
+	path = Plumble/jni/speex
+	url = git://git.xiph.org/speex.git/

--- a/Plumble/.gitmodules
+++ b/Plumble/.gitmodules
@@ -1,6 +1,0 @@
-[submodule "jni/celt"]
-	path = jni/celt
-	url = git://git.xiph.org/celt.git/
-[submodule "jni/speex"]
-	path = jni/speex
-	url = git://git.xiph.org/speex.git/


### PR DESCRIPTION
Hey Morlunk,

thanks for your work. Great to see somebody developing the mumble android app further.

In 0b57d549 you moved .gitmodules to a subdirectory. I think this is not possible, because that file should stay in the project root. Also i added a entry for the new referenced ActionBar. Maybe your Sourcetree or whatever made that for you.

Please reconsider this directory layout. Why not moving ActionBar to Pluble/libs where a the others libs resident and make Plumble the new root directory again?

Best Regards
Hubert
