### PR TITLE
Appearance Improvements of Thomas Hübner

### DIFF
--- a/Plumble/res/layout/nested_dropdown_item_slim.xml
+++ b/Plumble/res/layout/nested_dropdown_item_slim.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	android:layout_width="match_parent"
+	android:layout_height="30dp"
+	android:orientation="horizontal">
+
+	<ImageView
+		android:id="@+id/return_image_s"
+		android:layout_width="wrap_content"
+		android:layout_height="30dp"
+		android:scaleType="fitCenter"
+		android:src="@drawable/carriage_return" />
+
+	<TextView
+		android:id="@+id/channel_name_s"
+		android:layout_width="0dp"
+		android:layout_height="match_parent"
+		android:gravity="center|left"
+		android:text="@string/app_name"
+		android:textColor="#FFFFFF"
+		android:maxLines="1"
+		android:scrollHorizontally="true"
+		android:singleLine="true"
+		android:ellipsize="end"
+		android:layout_weight="1"/>
+</LinearLayout>

--- a/Plumble/res/values-de/preference_res.xml
+++ b/Plumble/res/values-de/preference_res.xml
@@ -34,6 +34,28 @@
 	    <item>voice</item>
 	</string-array>
 
+	<string-array name="rowheightText">
+		<item>Niedrig</item>
+		<item>Mittel</item>
+		<item>Höher</item>
+		<item>Sehr hoch</item>
+	</string-array>
+	<string-array name="rowheightValues">
+		<item>30</item>
+		<item>35</item>
+		<item>40</item>
+		<item>50</item>
+	</string-array>
+
+	<string-array name="colorizeText">
+		<item>Farben einschalten</item>
+		<item>Farben ausschalten</item>
+	</string-array>
+	<string-array name="colorizeValues">
+		<item>true</item>
+		<item>false</item>
+	</string-array>
+
 	<string name="authentication">Authentifizierung</string>
 	<string name="certificateFile">Zertifikatsdatei</string>
 	<string name="certificateFileSum">Das gewünschte P12 Zertifikats aus dem \"Plumble\" Verzeichnis auf dem externen Speicher.</string>
@@ -54,4 +76,10 @@
 	<string name="advancedAudio">Erweiterte Audioeigenschaften</string>
 	<string name="audioQuality">Audio Qualität</string>
 	<string name="noCert">Kein Zertifikat</string>
+	<string name="rowheight">Zeilenhöhe in Kanalauswahl</string>
+	<string name="rowheightSum">Legt die Höhe einer Zeile in der Kanalauswahl fest.</string>
+	<string name="colorizechannels">Kanäle in der Auswahl einfärben</string>
+	<string name="colorizechannelsSum">Hauptkanäle werden gelb, benutzte Kanäle cyan und stark genutzte Kanäle in Rot dargestellt.</string>
+	<string name="colorthreshold">Limit für zweite Farbe</string>
+	<string name="colorthresholdSum">Wenn diese Anzahl Benutzer erreicht ist, wird der Kanal in der Kanalauswahl Rot dargestellt.</string>
 </resources>

--- a/Plumble/res/values/preference_res.xml
+++ b/Plumble/res/values/preference_res.xml
@@ -34,6 +34,28 @@
 	    <item>voice</item>
 	</string-array>
 
+	<string-array name="rowheightText">
+		<item>Slim</item>
+		<item>Medium</item>
+		<item>Larger</item>
+		<item>Very Large</item>
+	</string-array>
+	<string-array name="rowheightValues">
+		<item>30</item>
+		<item>35</item>
+		<item>40</item>
+		<item>50</item>
+	</string-array>
+
+	<string-array name="colorizeText">
+		<item>Enable Colors</item>
+		<item>Disable Colors</item>
+	</string-array>
+	<string-array name="colorizeValues">
+		<item>true</item>
+		<item>false</item>
+	</string-array>
+
 	<string name="authentication">Authentication</string>
 	<string name="certificateFile">Certificate File</string>
 	<string name="certificateFileSum">The path of the P12 certificate you wish to use, placed in the \"Plumble\" folder on external storage.</string>
@@ -54,4 +76,10 @@
 	<string name="advancedAudio">Advanced Audio</string>
 	<string name="audioQuality">Audio quality</string>
 	<string name="noCert">No Certificate</string>
+	<string name="rowheight">Channellist row height</string>
+	<string name="rowheightSum">The height of a row in Channel selection.</string>
+	<string name="colorizechannels">Colorize channels</string>
+	<string name="colorizechannelsSum">Use colors to highlite root channels and used channels.</string>
+	<string name="colorthreshold">Threshold 2nd color</string>
+	<string name="colorthresholdSum">If this number of users is reached in a channel the channelname appears red.</string>
 </resources>

--- a/Plumble/res/xml/preferences.xml
+++ b/Plumble/res/xml/preferences.xml
@@ -1,27 +1,83 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<PreferenceScreen
-	xmlns:android="http://schemas.android.com/apk/res/android">
-	<PreferenceCategory android:title="@string/authentication">
-		<ListPreference android:key="certificatePath" android:title="@string/certificateFile" android:summary='@string/certificateFileSum'/>
-		<EditTextPreference android:title="@string/certificatePassword" android:summary="@string/certificatePasswordSum" android:key="certificatePassword"/>
-	</PreferenceCategory><PreferenceCategory android:title="@string/audioInput">
-		<ListPreference android:entries="@array/audioInputNames" android:entryValues="@array/audioInputValues" android:key="audioInputMethod" android:summary="@string/audioInputMethodSum" android:title="@string/audioInputMethod" android:defaultValue="voiceActivity"/><ListPreference android:dialogTitle="@string/callMode" android:entries="@array/callModeNames" android:entryValues="@array/callModeValues" android:key="callMode" android:summary="@string/callModeSum" android:title="@string/callMode" android:defaultValue="speakerphone"/>
-		<com.morlunk.mumbleclient.preference.SeekBarDialogPreference android:key="detectionThreshold" android:title="@string/detectionThreshold" android:summary="@string/detectionThresholdSum" android:defaultValue="14" android:max="28" multiplier="100"/>
-		<com.morlunk.mumbleclient.preference.KeySelectDialogPreference android:key="talkKey" android:title="@string/pttKey" android:summary="@string/pttKeySum"/>
-		
-	</PreferenceCategory>
-	<PreferenceCategory android:title="@string/appearance">
-		<ListPreference android:entries="@array/themeNames" android:entryValues="@array/themeValues" android:key="theme" android:summary="@string/themeSum" android:title="@string/theme" android:defaultValue="lightDark"/>
-	</PreferenceCategory>
-	<PreferenceCategory
-		android:title="@string/advancedAudio">
-		<EditTextPreference
-			android:title="@string/audioQuality"
-			android:defaultValue="60000"
-			android:key="quality"
-			android:inputType="number" />
-	</PreferenceCategory>
-	
-	
-	
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android" >
+
+    <PreferenceCategory android:title="@string/authentication" >
+        <ListPreference
+            android:key="certificatePath"
+            android:summary="@string/certificateFileSum"
+            android:title="@string/certificateFile" />
+
+        <EditTextPreference
+            android:key="certificatePassword"
+            android:summary="@string/certificatePasswordSum"
+            android:title="@string/certificatePassword" />
+    </PreferenceCategory>
+    <PreferenceCategory android:title="@string/audioInput" >
+        <ListPreference
+            android:defaultValue="voiceActivity"
+            android:entries="@array/audioInputNames"
+            android:entryValues="@array/audioInputValues"
+            android:key="audioInputMethod"
+            android:summary="@string/audioInputMethodSum"
+            android:title="@string/audioInputMethod" />
+        <ListPreference
+            android:defaultValue="speakerphone"
+            android:dialogTitle="@string/callMode"
+            android:entries="@array/callModeNames"
+            android:entryValues="@array/callModeValues"
+            android:key="callMode"
+            android:summary="@string/callModeSum"
+            android:title="@string/callMode" />
+
+        <com.morlunk.mumbleclient.preference.SeekBarDialogPreference
+            multiplier="100"
+            android:defaultValue="14"
+            android:key="detectionThreshold"
+            android:max="28"
+            android:summary="@string/detectionThresholdSum"
+            android:title="@string/detectionThreshold" />
+
+        <com.morlunk.mumbleclient.preference.KeySelectDialogPreference
+            android:key="talkKey"
+            android:summary="@string/pttKeySum"
+            android:title="@string/pttKey" />
+    </PreferenceCategory>
+    <PreferenceCategory android:title="@string/appearance" >
+        <ListPreference
+            android:defaultValue="lightDark"
+            android:entries="@array/themeNames"
+            android:entryValues="@array/themeValues"
+            android:key="theme"
+            android:summary="@string/themeSum"
+            android:title="@string/theme" />
+        <ListPreference
+            android:defaultValue="35"
+            android:entries="@array/rowheightText"
+            android:entryValues="@array/rowheightValues"
+            android:key="channellistrowheight"
+            android:summary="@string/rowheightSum"
+            android:title="@string/rowheight" />
+        <ListPreference
+            android:defaultValue="false"
+            android:entries="@array/colorizeText"
+            android:entryValues="@array/colorizeValues"
+            android:key="colorizechannellist"
+            android:summary="@string/colorizechannelsSum"
+            android:title="@string/colorizechannels" />
+
+        <EditTextPreference
+            android:defaultValue="5"
+            android:inputType="number"
+            android:key="colorthresholdnumusers"
+            android:summary="@string/colorthresholdSum"
+            android:title="@string/colorthreshold" />
+    </PreferenceCategory>
+    <PreferenceCategory android:title="@string/advancedAudio" >
+        <EditTextPreference
+            android:defaultValue="60000"
+            android:inputType="number"
+            android:key="quality"
+            android:title="@string/audioQuality" />
+    </PreferenceCategory>
+
 </PreferenceScreen>

--- a/Plumble/src/com/morlunk/mumbleclient/Settings.java
+++ b/Plumble/src/com/morlunk/mumbleclient/Settings.java
@@ -37,6 +37,15 @@ public class Settings {
 	public static final String PREF_LAST_CHANNEL = "lastChannels";
 	public static final String LAST_CHANNEL_PREFIX = "lastChannel_"; // TODO move this to db code or something. It's messy as hell.
 
+	public static final String PREF_CHANNELLIST_ROW_HEIGHT = "channellistrowheight";
+	public static final String DEFAULT_CHANNELLIST_ROW_HEIGHT = "30";
+
+	public static final String PREF_COLORIZE_CHANNELLIST = "colorizechannellist";
+	public static final String DEFAULT_COLORIZE_CHANNELLIST = "false";
+
+	public static final String PREF_COLORIZE_THRESHOLD = "colorthresholdnumusers";
+	public static final String DEFAULT_COLORIZE_THRESHOLD = "5";
+
 	private final SharedPreferences preferences;
 
 	public Settings(final Context ctx) {
@@ -93,5 +102,21 @@ public class Settings {
 	public void setLastChannel(int serverId, int channelId) {
 		preferences.edit()
 		.putInt(String.format("%s%d", LAST_CHANNEL_PREFIX, serverId), channelId).commit();
+	}
+
+	public int getChannelListRowHeight() {
+		return Integer.parseInt(preferences.getString(
+				Settings.PREF_CHANNELLIST_ROW_HEIGHT,
+				DEFAULT_CHANNELLIST_ROW_HEIGHT));
+	}
+
+	public Boolean getChannellistColorized() {
+		return preferences.getString(Settings.PREF_COLORIZE_CHANNELLIST,
+				DEFAULT_COLORIZE_CHANNELLIST).equals("true");
+	}
+
+	public int getColorizeThreshold() {
+		return Integer.parseInt(preferences.getString(
+				Settings.PREF_COLORIZE_THRESHOLD, DEFAULT_COLORIZE_THRESHOLD));
 	}
 }


### PR DESCRIPTION
- 3 New settings in "Appearance" section
  --- row height
  --- colorize yes/no
  --- Threshold for colorize heavy used channels

If a row height < 35 is given by user the list switches to the slim
design with num user in front of channelname and limit to one line. If
row height >=35 the legacy layout is used. Values are corrected to be
min 30 and max 50 (no clue whether a min/max limit is possible in the
preferences XML file - if yes it should be used there)

Colorize ON/OFF is self explaining as well as the threshold. I have
found no possibility to inactivate (grey out) the threshold setting if
colorize is NO. This should be done if possible
