### PR TITLE
Updated Polish translation

### DIFF
--- a/res/values-pl/strings.xml
+++ b/res/values-pl/strings.xml
@@ -80,7 +80,7 @@
     <string name="edit">Edytuj</string>
     <string name="delete">Usuń</string>
     <string name="retry">Ponów</string>
-    <string name="messageToUser">Wiadomość do użytkownika: \'%s\'</string>
+    <string name="messageToUser">Wiadomość do: \'%s\'</string>
     <string name="messageToChannel">Wiadomość do kanału</string>
     <string name="online">Online</string>
     <string name="offline">Offline</string>
@@ -89,4 +89,16 @@
     <string name="plumbleConnected">Plumble - Połączono</string>
     <string name="lostConnection">Utracono połączenie z serwerem.</string>
     <string name="resume">Wznów</string>
+    <string name="channel">Kanał</string>
+    <string name="server">Serwer</string>
+    <string name="chat_message_to">Do</string>
+    <string name="chat_notify_moved">%1$s został przeniesiony z kanału %2$s przez %3$s.</string>
+    <string name="chat_notify_muted_deafened">Ogłuszono oraz wyciszono mikrofon.</string>
+    <string name="chat_notify_muted">Wyciszono mikrofon.</string>
+    <string name="chat_notify_unmuted">Wyłączono wyciszenie mikrofonu.</string>
+    <string name="chat_notify_now_muted_deafened">%s jest teraz ogłuszony oraz wyciszony.</string>
+    <string name="chat_notify_now_muted">%s jest teraz wyciszony.</string>
+    <string name="chat_notify_now_unmuted">%s nie jest już wyciszony.</string>
+    <string name="chat_notify_connected">%s połączony.</string>
+    <string name="unknown">Nieznany</string>
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -96,7 +96,7 @@
     <string name="chat_notify_muted_deafened">Muted and deafened.</string>
     <string name="chat_notify_muted">Muted.</string>
     <string name="chat_notify_unmuted">Unmuted.</string>
-    <string name="chat_notify_now_muted_deafened" >%s is now muted and deafened.</string>
+    <string name="chat_notify_now_muted_deafened">%s is now muted and deafened.</string>
     <string name="chat_notify_now_muted">%s is now muted.</string>
     <string name="chat_notify_now_unmuted">%s is now unmuted.</string>
     <string name="chat_notify_connected">%s connected.</string>


### PR DESCRIPTION
Translation for 1.7 RC1 is ready but:
- I need separate string "%s is now unmuted and undeafened". - I can't use same string for unmuted for "unmuted and undeafeaned" event in polish
- Where is disconnected message?
