### PR TITLE
Make "delete server" button visually responsive

### DIFF
--- a/res/layout/server_list_row.xml
+++ b/res/layout/server_list_row.xml
@@ -40,7 +40,7 @@
                     android:id="@+id/server_row_delete"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:background="@null"
+                    android:background="?android:attr/selectableItemBackground"
                     android:src="@drawable/ic_action_delete_light" />
             </LinearLayout>
         


### PR DESCRIPTION
I just added the selectable item background attribute that the Holo theme provides, making it glow when focused/pressed on.
